### PR TITLE
feat: Implement print history and configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,63 @@
 仓库拿着发货清单打印标签。
 分工提高工作效率
 
-
-
 ![微信图片_20241129160326](https://github.com/user-attachments/assets/150a42e6-db82-4a21-a80b-bc06db3e8319)
 
-先安装版本（默认目录即可）：Ghostscript 10.04.0 for Windows (64 bit)
-https://www.ghostscript.com/releases/gsdnld.html
+## 安装与设置 (Installation and Setup)
 
-首先，D盘根目录新建两个文件夹，一个txt文件。
-“other“-常用打印文件，比如在打印过程中需要插入一些分隔页面以及平时常用的文件等；
-“temuskupdf”-设计好的SKU ID命名的pdf文件存放目录（通常是数百个数量）；
-“print_set.txt”-打印机名称，自行一行一个输入保存（因为有些打印机不想让它显示时这时候自己输入就很方便）；
+1.  **安装 Ghostscript:**
+    *   请先安装 Ghostscript 10.04.0 (或兼容版本)。推荐使用64位版本。
+    *   下载链接: [Ghostscript Downloads](https://www.ghostscript.com/releases/gsdnld.html)
+    *   (Please install Ghostscript 10.04.0 (or a compatible version) first. The 64-bit version is recommended.)
 
-输入SKU ID后回车自动匹配“temuskupdf”中的文件，如存在，回车后会跳转到输入“数量”，输入数量之后再次敲击回车开始打印。
+2.  **文件夹和文件设置 (Folder and File Setup):**
+    *   以下为程序默认使用的文件夹名称和文件，建议首次运行时按默认设置，程序会自动在需要时创建相关配置文件。
+    *   (The following are the default folder names and files used by the program. It's recommended to use the defaults on the first run; the program will create necessary configuration files if they don't exist.)
+        *   `D:\other` - **默认**常用打印文件存放目录。用于存放例如分隔页或日常打印的PDF文件。
+        *   (`D:\other` - **Default** directory for commonly used print files, e.g., separator pages or frequently printed PDFs.)
+        *   `D:\temuskupdf` - **默认**SKU PDF文件存放目录。存放以SKU ID命名的PDF标签文件。
+        *   (`D:\temuskupdf` - **Default** directory for SKU PDF files. Stores PDF label files named with SKU IDs.)
+        *   `print_set.txt` - **默认**打印机配置文件名。用于指定程序中可选的打印机列表，每行一个打印机名称。
+        *   (`print_set.txt` - **Default** printer configuration filename. Used to specify the list of available printers in the program, one printer name per line.)
+    *   **重要提示 (Important Note):**
+        *   这些路径现在是可配置的。首次运行时如果 `printer_config.json` 文件不存在，程序会自动创建并填入这些默认路径。您可以编辑 `printer_config.json` 文件来修改这些路径。可配置的键名分别为 `temuskupdf_folder`、`other_folder` 和 `print_set_file`。
+        *   (These paths are now configurable. If `printer_config.json` does not exist upon first run, it will be created with these default paths. You can edit `printer_config.json` to change these paths if needed. The configurable keys are `temuskupdf_folder`, `other_folder`, and `print_set_file`.)
 
-程序依赖gswin64c.exe打印接口全程静默打印。
-后续考虑添加打印记录本地保存，以方便后期核对出库数量，打印记录设置“重打”按钮，手动删除某条打印记录等因为偶尔打错的记录删除掉可以方便正确统计出库数量。
+## 使用说明 (Usage)
+
+输入SKU ID后回车，程序会自动在配置的“SKU PDF文件存放目录”（默认为 `D:\temuskupdf`）中查找对应的PDF文件。
+如果文件存在，光标会自动跳转到“数量”输入框，输入打印数量后再次敲击回车即可开始打印。
+程序依赖 Ghostscript (`gswin64c.exe` 或 `gswin32c.exe`) 实现静默打印。
+
+(After entering the SKU ID and pressing Enter, the program automatically searches for the corresponding PDF file in the configured "SKU PDF directory" (default is `D:\temuskupdf`). If the file exists, the cursor will jump to the "quantity" input field. Enter the quantity and press Enter again to start printing. The program relies on Ghostscript for silent printing.)
+
+## 功能更新 (Feature Updates)
+
+### 打印历史记录 (Print History)
+
+*   程序现在会自动记录每次成功的打印任务。
+    *   (The program now automatically records every successful print job.)
+*   打印记录保存在程序目录下的 `print_log.csv` 文件中。该文件包含以下信息：时间戳 (Timestamp)、SKU/文件名 (SKU/Filename)、数量 (Quantity)、打印机 (Printer) 和状态 (Status)。
+    *   (Print records are saved in `print_log.csv` in the program directory. This file includes: Timestamp, SKU/Filename, Quantity, Printer, and Status.)
+*   主界面新增“打印历史”选项卡，提供以下功能：
+    *   (A "Print History" tab has been added to the main interface, providing the following functions:)
+    *   **查看所有打印记录**: 默认按时间倒序排列。
+        *   (View all print records, sorted by time in descending order by default.)
+    *   **刷新记录**: 重新加载并显示最新的打印历史。
+        *   (Refresh Records: Reload and display the latest print history.)
+    *   **重打**: 快速重新打印选定的历史记录。
+        *   (Reprint: Quickly reprint a selected historical job.)
+    *   **删除**: 删除选定的单条打印记录（操作前会有确认提示）。
+        *   (Delete: Delete a selected single print record (with confirmation before action).)
+    *   **清空所有记录**: 删除所有打印历史记录（操作前会有确认提示）。
+        *   (Clear All Records: Delete all print history records (with confirmation before action).)
+
+## 后续考虑 (Future Considerations)
+
+后续可考虑的功能包括：更高级的打印队列管理、用户权限控制、远程管理界面、更灵活的错误处理和日志分级等。
+
+(Future considerations could include: more advanced print queue management, user permissions, a remote management interface, more flexible error handling and log levels, etc.)
+
+## 关于 (About)
 代码都是LLM一步一步调试生成，本人一句也不会写。有问题别问我~
-
-
+(The code was generated step-by-step with an LLM. I didn't write a single line myself. Don't ask me if you have problems~)

--- a/print_logger.py
+++ b/print_logger.py
@@ -1,0 +1,216 @@
+import csv
+import os
+from datetime import datetime
+
+LOG_FILE_NAME = "print_log.csv"
+LOG_HEADER = ["Timestamp", "SKU/Filename", "Quantity", "Printer", "Status"]
+
+def get_log_file_path() -> str:
+    """Returns the absolute path to the log file."""
+    # For now, place it in the same directory as this script.
+    # In a real application, this might be a user-specific data directory.
+    return os.path.abspath(LOG_FILE_NAME)
+
+def log_print_job(timestamp: str, sku_or_filename: str, quantity: int, printer_name: str, status: str):
+    """Appends a print job record to the CSV log file.
+
+    Args:
+        timestamp: The timestamp of the print job (e.g., "YYYY-MM-DD HH:MM:SS").
+        sku_or_filename: The SKU or filename of the item printed.
+        quantity: The number of copies printed.
+        printer_name: The name of the printer used.
+        status: The status of the print job (e.g., "Printed", "Failed").
+    """
+    log_file = get_log_file_path()
+    file_exists = os.path.isfile(log_file)
+
+    try:
+        with open(log_file, 'a', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+            if not file_exists or os.path.getsize(log_file) == 0:
+                writer.writerow(LOG_HEADER)
+            writer.writerow([timestamp, sku_or_filename, quantity, printer_name, status])
+    except IOError as e:
+        print(f"Error writing to log file {log_file}: {e}")
+
+def read_print_log() -> list[list[str]]:
+    """Reads all records from the print log CSV file.
+
+    Returns:
+        A list of lists, where each inner list represents a row (excluding the header).
+        Returns an empty list if the log file doesn't exist.
+    """
+    log_file = get_log_file_path()
+    if not os.path.isfile(log_file):
+        return []
+
+    records = []
+    try:
+        with open(log_file, 'r', newline='', encoding='utf-8') as csvfile:
+            reader = csv.reader(csvfile)
+            header = next(reader, None)  # Skip header
+            if header: # Proceed only if header was read
+                for row in reader:
+                    if row: # Ensure row is not empty
+                        records.append(row)
+    except StopIteration:
+        # This can happen if the file is empty (only header or nothing)
+        pass
+    except IOError as e:
+        print(f"Error reading from log file {log_file}: {e}")
+    return records
+
+def delete_print_log_entry(timestamp_to_delete: str) -> bool:
+    """Deletes a specific entry from the print log CSV file based on the timestamp.
+
+    Args:
+        timestamp_to_delete: The exact timestamp of the log entry to delete.
+
+    Returns:
+        True if an entry was found and deletion was attempted (file rewritten),
+        False otherwise (entry not found, file not found, or I/O error).
+    """
+    log_file = get_log_file_path()
+    if not os.path.isfile(log_file):
+        print(f"Log file {log_file} not found.")
+        return False
+
+    rows_to_keep = []
+    deleted_count = 0
+    header_row = []
+
+    try:
+        with open(log_file, 'r', newline='', encoding='utf-8') as csvfile:
+            reader = csv.reader(csvfile)
+            header_row = next(reader, None)
+            if not header_row: # Empty or malformed file
+                print(f"Log file {log_file} is empty or has no header.")
+                return False
+
+            rows_to_keep.append(header_row) # Keep the header
+
+            for row in reader:
+                if row: # Ensure row is not empty
+                    if row[0] == timestamp_to_delete:
+                        deleted_count += 1
+                    else:
+                        rows_to_keep.append(row)
+
+        if deleted_count == 0:
+            print(f"No log entry found with timestamp: {timestamp_to_delete}")
+            return False # Entry not found
+
+        # Rewrite the file with the filtered rows
+        with open(log_file, 'w', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerows(rows_to_keep)
+
+        print(f"Successfully deleted {deleted_count} log entry(s) with timestamp: {timestamp_to_delete}")
+        return True
+
+    except StopIteration: # Should be caught by header check, but good practice
+        print(f"Error: Log file {log_file} seems to be empty or improperly formatted (StopIteration).")
+        return False
+    except IndexError: # If a row doesn't have a timestamp column (e.g. malformed)
+        print(f"Error: Malformed row found in {log_file} while checking timestamp.")
+        return False
+    except IOError as e:
+        print(f"Error during file operation on {log_file}: {e}")
+        return False
+
+def clear_all_print_logs() -> bool:
+    """Clears all entries from the print log CSV file, leaving only the header.
+
+    Returns:
+        True if the log was successfully cleared (or was already empty/missing and then created with header).
+        False if an I/O error occurred.
+    """
+    log_file = get_log_file_path()
+    try:
+        # Overwrite the file, writing only the header.
+        # This handles cases where the file doesn't exist (it will be created)
+        # or is corrupted (it will be overwritten).
+        with open(log_file, 'w', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(LOG_HEADER)
+        print(f"Successfully cleared all print logs. File '{log_file}' now contains only the header.")
+        return True
+    except IOError as e:
+        print(f"Error clearing print log file {log_file}: {e}")
+        return False
+
+if __name__ == '__main__':
+    # Example usage:
+    # Ensure the logger works by itself for testing
+    print(f"Log file will be at: {get_log_file_path()}")
+
+    # Get current timestamp for example
+    example_ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    log_print_job(example_ts, "TEST_SKU_001.pdf", 1, "Printer_1", "Printed")
+    log_print_job(example_ts, "ANOTHER_FILE.pdf", 5, "Printer_2", "Printed")
+    log_print_job(example_ts, "FAIL_DOC.pdf", 1, "Printer_1", "Failed")
+
+    print(f"Example log entries written to {LOG_FILE_NAME}.")
+
+    # Test reading the log
+    print("\nReading log entries (before deletion):")
+    log_data = read_print_log()
+    if log_data:
+        for row in log_data:
+            print(row)
+    else:
+        print("No log data found or error reading log.")
+
+    # Test deleting an entry - use a timestamp from one of the logged examples
+    # Important: For a real test, this timestamp must exist from a previous run or be logged above.
+    if log_data: # Only try to delete if there was data
+        timestamp_to_try_delete = log_data[0][0] # Try to delete the first actual data entry's timestamp
+        print(f"\nAttempting to delete entry with timestamp: {timestamp_to_try_delete}")
+        if delete_print_log_entry(timestamp_to_try_delete):
+            print(f"Deletion successful for {timestamp_to_try_delete}.")
+        else:
+            print(f"Deletion failed for {timestamp_to_try_delete}.")
+
+        print("\nReading log entries (after attempted deletion):")
+        log_data_after_delete = read_print_log()
+        if log_data_after_delete:
+            for row in log_data_after_delete:
+                print(row)
+        else:
+            print("No log data found or error reading log (after delete).")
+
+    # Test deleting a non-existent entry
+    non_existent_ts = "2000-01-01 00:00:00"
+    print(f"\nAttempting to delete non-existent entry with timestamp: {non_existent_ts}")
+    if delete_print_log_entry(non_existent_ts):
+        print(f"Deletion successful for {non_existent_ts} (this should not happen).")
+    else:
+        print(f"Deletion failed for {non_existent_ts} (as expected).")
+
+    # Test clearing all logs
+    print("\nAttempting to clear all log entries...")
+    if clear_all_print_logs():
+        print("Clearing all logs reported success.")
+    else:
+        print("Clearing all logs reported failure.")
+
+    print("\nReading log entries (after clearing all):")
+    log_data_after_clear_all = read_print_log()
+    if not log_data_after_clear_all: # Expecting empty list
+        print("Log data is empty as expected after clearing all.")
+    elif len(log_data_after_clear_all) == 0 : # Also check for empty list this way
+         print("Log data is an empty list as expected after clearing all.")
+    else:
+        print("Log data after clearing all (should be empty or header only):")
+        for row in log_data_after_clear_all:
+            print(row) # Should ideally print nothing if read_print_log correctly skips header
+
+    # Log one more entry to ensure logging still works after clearing
+    print("\nLogging one more entry after clearing...")
+    final_ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    log_print_job(final_ts, "FINAL_ENTRY.pdf", 1, "Printer_Test", "Printed")
+    final_log_data = read_print_log()
+    print("Final log data:")
+    for row in final_log_data:
+        print(row)

--- a/printer_config.py
+++ b/printer_config.py
@@ -5,21 +5,45 @@ import json
 class PrinterConfig:
     def __init__(self):
         self.config_file = "printer_config.json"
+        self.default_paths = {
+            'temuskupdf_folder': 'D:\\temuskupdf',
+            'other_folder': 'D:\\other',
+            'print_set_file': 'print_set.txt'
+        }
         self.config = self.load_config()
 
     def load_config(self):
+        config_changed = False
         if os.path.exists(self.config_file):
             with open(self.config_file, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        return {
-            'selected_printers': [],
-            'last_sizes': {},
-            'last_paths': {}
-        }
+                config = json.load(f)
+        else:
+            config = {
+                'selected_printers': [],
+                'last_sizes': {},
+                'last_paths': {}
+            }
+            config_changed = True # If file doesn't exist, it will be new, so defaults will be added.
+
+        for key, value in self.default_paths.items():
+            if key not in config:
+                config[key] = value
+                config_changed = True
+
+        if config_changed:
+            # Save immediately if defaults were added or if the file was newly created
+            self._save_config_data(config)
+
+        return config
+
+    def _save_config_data(self, config_data):
+        # Internal method to save config data, used by load_config and save_config
+        with open(self.config_file, 'w', encoding='utf-8') as f:
+            json.dump(config_data, f, indent=4)
 
     def save_config(self):
-        with open(self.config_file, 'w', encoding='utf-8') as f:
-            json.dump(self.config, f, indent=4)
+        # Public method to save the current state of self.config
+        self._save_config_data(self.config)
 
     def get_config(self):
         return self.config

--- a/printer_manager.py
+++ b/printer_manager.py
@@ -1,17 +1,19 @@
-
 # printer_manager.py
 import os
 import sys
 import tempfile
 import win32print
-import win32api
+from functools import partial
+
 from PySide6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                                QHBoxLayout, QCheckBox, QLabel, QPushButton,
                                QFileDialog, QLineEdit, QSpinBox, QListWidget,
-                               QGroupBox, QMessageBox, QFrame)
+                               QGroupBox, QMessageBox, QFrame, QTabWidget,
+                               QTableWidget, QTableWidgetItem, QHeaderView)
 from PySide6.QtCore import Qt, QDateTime
 from printer_config import PrinterConfig
 from printer_panel import PrinterPanel
+from print_logger import read_print_log, LOG_HEADER, delete_print_log_entry, clear_all_print_logs # Added clear_all_print_logs
 
 def read_printers_from_file(file_path: str) -> list:
     printers = []
@@ -25,62 +27,221 @@ class PrinterManager(QMainWindow):
         super().__init__()
         self.printer_config = PrinterConfig()
         self.config = self.printer_config.get_config()
+
+        self.temuskupdf_folder = self.config.get('temuskupdf_folder', 'D:\\temuskupdf')
+        self.other_folder = self.config.get('other_folder', 'D:\\other')
+        self.print_set_file = self.config.get('print_set_file', 'print_set.txt')
+
         self.printer_panels = {}
         self.temp_dir = tempfile.mkdtemp()
         self.default_printer = win32print.GetDefaultPrinter()
+        self.history_table = None
+        self.print_tab_widget = None
 
         self.gs_path = self._find_ghostscript()
         if not self.gs_path:
-            QMessageBox.warning(self, "警告", "未找到 Ghostscript，请确保正确安装了 Ghostscript 10.04.0")
+            QMessageBox.warning(self, "警告", "未找到 Ghostscript，请确保正确安装了 Ghostscript 10.04.0 或兼容版本。")
 
         self._init_ui()
 
     def _find_ghostscript(self):
         possible_paths = [
-            r"C:\Program Files\gs\gs10.04.0\bin\gswin64c.exe",  # 64位版本
-            r"C:\Program Files (x86)\gs\gs10.04.0\bin\gswin32c.exe",  # 32位版本
-            r"C:\Program Files\gs\gs10.04.0\bin\gswin64.exe",
-            r"C:\Program Files (x86)\gs\gs10.04.0\bin\gswin32.exe"
+            r"C:\Program Files\gs\gs10.04.0\bin\gswin64c.exe",
+            r"C:\Program Files (x86)\gs\gs10.04.0\bin\gswin32c.exe",
         ]
-
         for path in possible_paths:
             if os.path.exists(path):
                 return path
-
         try:
-            result = subprocess.run(['where', 'gswin64c.exe'], capture_output=True, text=True, check=True)
-            if result.stdout.strip():
-                return result.stdout.strip().split('\n')[0]
-        except:
-            try:
-                result = subprocess.run(['where', 'gswin32c.exe'], capture_output=True, text=True, check=True)
-                if result.stdout.strip():
-                    return result.stdout.strip().split('\n')[0]
-            except:
-                pass
-
+            import subprocess
+            result = subprocess.run(['where', 'gswin64c.exe'], capture_output=True, text=True, check=True, shell=True)
+            if result.stdout.strip(): return result.stdout.strip().split('\n')[0]
+            result = subprocess.run(['where', 'gswin32c.exe'], capture_output=True, text=True, check=True, shell=True)
+            if result.stdout.strip(): return result.stdout.strip().split('\n')[0]
+        except Exception:
+            pass
         return None
 
     def __del__(self):
         try:
-            shutil.rmtree(self.temp_dir)
-        except:
-            pass
+            import shutil
+            if hasattr(self, 'temp_dir') and os.path.exists(self.temp_dir):
+                shutil.rmtree(self.temp_dir)
+        except Exception as e:
+            print(f"Error cleaning up temp directory: {e}")
 
     def _init_ui(self):
         self.setWindowTitle('打印管理系统')
-        self.setGeometry(100, 100, 500, 300)
+        self.setGeometry(100, 100, 950, 700)
 
-        central_widget = QWidget()
-        self.setCentralWidget(central_widget)
-        main_layout = QVBoxLayout(central_widget)
+        self.tabs_widget = QTabWidget()
+        self.setCentralWidget(self.tabs_widget)
 
-        # 读取打印机列表
-        printers = read_printers_from_file("print_set.txt")
-        for printer in printers:
-            self.create_printer_panel(printer)
+        self.print_tab_widget = QWidget()
+        self.print_tab_layout = QVBoxLayout(self.print_tab_widget)
 
-    def create_printer_panel(self, printer_name: str):
+        printers = read_printers_from_file(self.print_set_file)
+        if not printers:
+            no_printers_label = QLabel(f"没有在 {self.print_set_file} 文件中找到打印机。\n请检查文件内容和路径设置。")
+            no_printers_label.setAlignment(Qt.AlignCenter)
+            self.print_tab_layout.addWidget(no_printers_label)
+        else:
+            for printer_name in printers:
+                self.create_printer_panel(printer_name, self.print_tab_layout)
+
+        self.tabs_widget.addTab(self.print_tab_widget, "打印")
+
+        history_tab_widget = QWidget()
+        history_layout = QVBoxLayout(history_tab_widget)
+
+        # Top button layout for Refresh and Clear All
+        top_button_layout = QHBoxLayout()
+
+        refresh_button = QPushButton("刷新记录")
+        refresh_button.clicked.connect(self._load_print_history)
+        top_button_layout.addWidget(refresh_button)
+
+        top_button_layout.addStretch(1) # Add stretch to push Clear All to the right
+
+        clear_all_button = QPushButton("清空所有记录")
+        clear_all_button.setStyleSheet("QPushButton { color: red; }") # Make it look dangerous
+        clear_all_button.clicked.connect(self._handle_clear_all_records_button_clicked)
+        top_button_layout.addWidget(clear_all_button)
+
+        history_layout.addLayout(top_button_layout) # Add the button layout to the main history tab layout
+
+        self.history_table = QTableWidget()
+        self.action_column_title = "操作"
+        self.history_table_headers = LOG_HEADER + [self.action_column_title]
+        self.history_table.setColumnCount(len(self.history_table_headers))
+        self.history_table.setHorizontalHeaderLabels(self.history_table_headers)
+        self.history_table.setSortingEnabled(True)
+
+        self.history_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        action_column_idx = self.history_table_headers.index(self.action_column_title)
+        self.history_table.horizontalHeader().setSectionResizeMode(action_column_idx, QHeaderView.Fixed)
+        self.history_table.setColumnWidth(action_column_idx, 160)
+
+        history_layout.addWidget(self.history_table) # Add table below buttons
+
+        self.tabs_widget.addTab(history_tab_widget, "打印历史")
+
+        self._load_print_history()
+
+    def create_printer_panel(self, printer_name: str, layout: QVBoxLayout):
         panel = PrinterPanel(printer_name, self, self.printer_config, self)
         self.printer_panels[printer_name] = panel
-        self.centralWidget().layout().addWidget(panel.panel)
+        layout.addWidget(panel.panel)
+
+    def _load_print_history(self):
+        if not self.history_table:
+            return
+
+        log_data = read_print_log()
+        self.history_table.setSortingEnabled(False)
+        self.history_table.setRowCount(0)
+
+        if not log_data:
+            self.history_table.setSortingEnabled(True)
+            return
+
+        self.history_table.setRowCount(len(log_data))
+        action_column_idx = self.history_table_headers.index(self.action_column_title)
+
+        for row_idx, record in enumerate(reversed(log_data)):
+            for col_idx, item_text in enumerate(record):
+                table_item = QTableWidgetItem(item_text)
+                table_item.setFlags(table_item.flags() & ~Qt.ItemIsEditable)
+                self.history_table.setItem(row_idx, col_idx, table_item)
+
+            timestamp_for_buttons = record[0]
+            sku_basename = record[1]
+            quantity_str = record[2]
+            printer_name_for_reprint = record[3]
+
+            try:
+                quantity = int(quantity_str)
+            except ValueError:
+                quantity = 1
+                print(f"Warning: Could not parse quantity '{quantity_str}' for log entry: {record}. Defaulting to 1.")
+
+            action_widget = QWidget()
+            action_layout = QHBoxLayout(action_widget)
+            action_layout.setContentsMargins(5, 0, 5, 0)
+            action_layout.setSpacing(5)
+
+            reprint_button = QPushButton("重打")
+            reprint_button.clicked.connect(
+                partial(self._handle_reprint_button_clicked,
+                        printer_name_for_reprint,
+                        sku_basename,
+                        quantity)
+            )
+            action_layout.addWidget(reprint_button)
+
+            delete_button = QPushButton("删除")
+            delete_button.clicked.connect(
+                partial(self._handle_delete_button_clicked, timestamp_for_buttons)
+            )
+            action_layout.addWidget(delete_button)
+
+            self.history_table.setCellWidget(row_idx, action_column_idx, action_widget)
+
+        self.history_table.setSortingEnabled(True)
+
+    def _handle_reprint_button_clicked(self, printer_name: str, sku_basename: str, quantity: int):
+        target_panel = self.printer_panels.get(printer_name)
+        if not target_panel:
+            QMessageBox.warning(self, "重打印错误", f"打印机 '{printer_name}' 当前未配置或不可用。")
+            return
+
+        if not self.temuskupdf_folder:
+             QMessageBox.critical(self, "配置错误", "Temuskupdf 文件夹路径未在配置中设置。")
+             return
+        full_path = os.path.join(self.temuskupdf_folder, sku_basename)
+
+        if not os.path.exists(full_path):
+            QMessageBox.warning(self, "重打印错误", f"文件 '{full_path}' 不再存在，无法重打印。")
+            return
+
+        if self.print_tab_widget:
+            self.tabs_widget.setCurrentWidget(self.print_tab_widget)
+
+        target_panel.file_path.setText(full_path)
+        target_panel.copies_spinbox.setValue(quantity)
+        target_panel.panel.setFocus()
+        target_panel.file_path.setFocus()
+        target_panel._print_file()
+
+    def _handle_delete_button_clicked(self, timestamp_to_delete: str):
+        reply = QMessageBox.question(self, '确认删除',
+                                     f"您确定要删除这条打印记录吗？\n时间戳: {timestamp_to_delete}",
+                                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+
+        if reply == QMessageBox.Yes:
+            deleted = delete_print_log_entry(timestamp_to_delete)
+            if deleted:
+                QMessageBox.information(self, "删除成功", "选择的打印记录已成功删除。")
+                self._load_print_history()
+            else:
+                QMessageBox.warning(self, "删除失败", "未能删除选择的打印记录。\n记录可能已被移除或发生文件错误。")
+
+    def _handle_clear_all_records_button_clicked(self):
+        reply = QMessageBox.question(self, '确认清空所有记录',
+                                     "您确定要删除所有打印记录吗？\n此操作无法撤销！",
+                                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+
+        if reply == QMessageBox.Yes:
+            cleared = clear_all_print_logs()
+            if cleared:
+                QMessageBox.information(self, "清空成功", "所有打印记录已成功删除。")
+                self._load_print_history() # Refresh the table, it should be empty
+            else:
+                QMessageBox.warning(self, "清空失败", "清空所有打印记录失败。\n可能发生文件错误。")
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    manager = PrinterManager()
+    manager.show()
+    sys.exit(app.exec())

--- a/printer_panel.py
+++ b/printer_panel.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import Qt, QDateTime, QEvent
 from typing import Optional
 from pathlib import Path
 import subprocess
+from print_logger import log_print_job
 
 
 
@@ -100,14 +101,14 @@ class PrinterPanel:
         file_name = self.file_path.text().strip()
         if not file_name.endswith('.pdf'):
             file_name += '.pdf'
-        folder_path = Path("D:\\temuskupdf")
+        folder_path = Path(self.manager.temuskupdf_folder) # Use configured path
         full_path = os.path.join(folder_path, file_name)
         if os.path.exists(full_path):
             self.file_path.setText(full_path)
             self.copies_spinbox.setValue(0)  # 将打印数量清空
             self.copies_spinbox.setFocus()
         else:
-            QMessageBox.warning(self.parent_widget, "警告", "文件不存在")
+            QMessageBox.warning(self.parent_widget, "警告", f"文件不存在: {full_path}")
 
     def _handle_spinbox_key_press(self, event):
         if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
@@ -167,6 +168,16 @@ class PrinterPanel:
                 filename = os.path.basename(file_path)
                 current_time = QDateTime.currentDateTime().toString("yyyy-MM-dd hh:mm:ss")
                 copies = self.copies_spinbox.value()
+
+                # Log the print job
+                log_print_job(
+                    timestamp=current_time,
+                    sku_or_filename=filename,
+                    quantity=copies,
+                    printer_name=self.printer_name,
+                    status="Printed"
+                )
+
                 new_item = f"{current_time} - 打印文件: {filename} (份数: {copies}) - 已打印"
                 self.queue_list.insertItem(0, new_item)
                 self.file_path.clear()
@@ -200,7 +211,7 @@ class PrinterPanel:
             return None
 
     def _load_common_files(self):
-        common_files_folder = Path("D:\\other")
+        common_files_folder = Path(self.manager.other_folder) # Use configured path
         if common_files_folder.exists():
             for file in common_files_folder.glob("*.pdf"):
                 self.common_files_list.addItem(file.name)
@@ -210,11 +221,11 @@ class PrinterPanel:
 
     def _print_common_file(self, item):
         file_name = item.text()
-        folder_path = Path("D:\\other")
+        folder_path = Path(self.manager.other_folder) # Use configured path
         full_path = os.path.join(folder_path, file_name)
         if os.path.exists(full_path):
             self.file_path.setText(full_path)
             self.copies_spinbox.setValue(1)
             self._print_file()
         else:
-            QMessageBox.warning(self.parent_widget, "警告", "文件不存在")
+            QMessageBox.warning(self.parent_widget, "警告", f"文件不存在: {full_path}")


### PR DESCRIPTION
This commit introduces several enhancements to the printing utility:

1.  **Configurable Paths:**
    - Paths for the SKU PDF folder, common files folder, and printer list file are now configurable via `printer_config.json`.
    - Default paths are used if the configuration file is missing or these keys are not set, and the defaults are saved on first run.

2.  **Print History Logging:**
    - All successful print jobs are now logged to `print_log.csv`.
    - Logged information includes: Timestamp, SKU/Filename, Quantity, Printer, and Status.

3.  **Print History UI:**
    - A new "Print History" tab displays logged print jobs.
    - Features include:
        - Viewing records in a sortable table (newest first by default).
        - "Refresh" button to reload logs. - "Reprint" button for each entry to quickly reprint a job. - "Delete" button for each entry to remove it from the log (with confirmation). - "Clear All Records" button to wipe the entire print history (with confirmation).

4.  **Code Structure:**
    - Introduced `print_logger.py` for handling log operations.
    - Refactored `printer_manager.py` and `printer_panel.py` to support new features and use configurable paths.

5.  **Documentation:**
    - Updated `README.md` to reflect these new features and configuration options.