### PR TITLE
fix: Improve print flow based on your feedback

### DIFF
--- a/printer_panel.py
+++ b/printer_panel.py
@@ -177,6 +177,9 @@ class PrinterPanel:
                     printer_name=self.printer_name,
                     status="Printed"
                 )
+                # Refresh the history tab in the main manager UI
+                if self.manager and hasattr(self.manager, '_load_print_history'):
+                    self.manager._load_print_history()
 
                 new_item = f"{current_time} - 打印文件: {filename} (份数: {copies}) - 已打印"
                 self.queue_list.insertItem(0, new_item)
@@ -225,7 +228,8 @@ class PrinterPanel:
         full_path = os.path.join(folder_path, file_name)
         if os.path.exists(full_path):
             self.file_path.setText(full_path)
-            self.copies_spinbox.setValue(1)
+            # The self.copies_spinbox already contains the desired quantity.
+            # No need to set it to 1 anymore.
             self._print_file()
         else:
             QMessageBox.warning(self.parent_widget, "警告", f"文件不存在: {full_path}")


### PR DESCRIPTION
This commit addresses two points of your feedback to enhance the printing workflow:

1.  **Automatic Print History Refresh:**
    - The "Print History" tab now automatically refreshes after any successful print operation (from SKU input or common files).
    - This ensures the displayed log is always up-to-date without manual intervention, with the latest print appearing at the top.

2.  **Correct Quantity for Common Files:**
    - When printing a file by double-clicking it in the "Common print files" list, the system now uses the quantity currently specified in that printer panel's "Print Quantity" spinbox.
    - This replaces the previous behavior where common files always printed with a quantity of 1.